### PR TITLE
make the unknown cause actually say unknown

### DIFF
--- a/src/main/java/org/polyfrost/crashpatch/mixin/MixinCrashReport.java
+++ b/src/main/java/org/polyfrost/crashpatch/mixin/MixinCrashReport.java
@@ -33,7 +33,7 @@ public class MixinCrashReport implements CrashReportHook {
     @Inject(method = "populateEnvironment", at = @At("TAIL"))
     private void afterPopulateEnvironment(CallbackInfo ci) {
         ModContainer susMod = ModIdentifier.INSTANCE.identifyFromStacktrace(cause);
-        crashpatch$suspectedMod = (susMod == null ? "None" : susMod.getName());
+        crashpatch$suspectedMod = (susMod == null ? "Unknown" : susMod.getName());
     }
 
     @Inject(method = "populateEnvironment", at = @At("HEAD"))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When no solution for a crash is found, CrashPatch says something along the lines of "This could have been caused by... None". This is confusing, as saying None makes it seem like it shouldn't have crashed, when in reality the issue is just unknown.

This PR has not been tested.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Saw someone on discord confused about what "None" meant.

## How to test
<!-- Provide steps to test this PR -->
Crash for unknown reasons.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Update crash message to say Unknown instead of None if a "sus mod" is not found
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->